### PR TITLE
Add hosts not networks

### DIFF
--- a/ssltest.py
+++ b/ssltest.py
@@ -253,8 +253,12 @@ def clean_hostlist(args):
         else:
             hosts.append(i)
     result = []
-    for i in networks:
-        result.append(i)
+    for network in networks:
+        if network.size >= opts.threads:
+            result.append(network)
+        else:
+            for i in network:
+                hosts.append(str(i))
     if hosts:
         result.append(hosts)
     return result


### PR DESCRIPTION
When scanning larger amount of smaller networks (like /30) with 1000 threads only certain amount of hosts is scanned at once even there are some free threads. By adding just the hosts and not networks we can fully utilize all the threads and speed up the scanning significantly
